### PR TITLE
Update staking module configuration constants in config.go

### DIFF
--- a/x/config/config.go
+++ b/x/config/config.go
@@ -2,14 +2,15 @@ package config
 
 // Contract addresses and other configuration constants for the staking module
 const (
-	ChainID                   = 90009
+	ChainID                   = 90000
 	// OnlineServerCountContract = "0xaA51C7e32dA1266447909b6C40772276A43453e8" //closed in staging
-	OnlineServerCountContract = "0xaA51C7e32dA1266447909b6C40772276A43453e8" //open in staging
+	OnlineServerCountContract = "0xF82896e2a53f3137ed65e9DAE9aF277188073aD7" //open in staging
 	// NFTContractAddress is the address of the NFT contract that validators must own tokens from
-	NFTContractAddress = "0x1c09B13B4Ea885CAF8b07a69231Ace3B0cCd91Bf"
+	NFTContractAddress = "0x060af1dDe407d7aEdE0FDdCea4FA0708086778Cf"
 	// WalletStateContractAddress is the address of the contract that stores validator requirements
-	WalletStateContractAddress = "0x54Bb36Ac0887242D6d77562Acf2f34c68477b99C"
+	WalletStateContractAddress = "0x20f310e17eba79776e4531F64993Eb4febA3a661"
 
-	ValidatorApprovalContractAddress = "0x9C72445A145f6C45D02188074F3338a65D0b6c9C"
+	ValidatorApprovalContractAddress = "0x97dEb2D3e2C48cB85aD69d91e004C1809b22b1cE"
 )
 
+``


### PR DESCRIPTION
- Changed ChainID from 90009 to 90000 for consistency.
- Updated OnlineServerCountContract, NFTContractAddress, WalletStateContractAddress, and ValidatorApprovalContractAddress to new values for improved accuracy in the staking module.