### PR TITLE
Enable duplicate IPs for Docker/Tailscale compatibility across multip…

### DIFF
--- a/multi_seed_node.sh
+++ b/multi_seed_node.sh
@@ -303,6 +303,14 @@ initialize_second_seed() {
         sed -i '/^\[grpc\]/,/^\[/ s|^enable = false|enable = true|' "$APP_TOML"
     fi
     
+    # Allow duplicate IPs (for Docker NAT / Tailscale mesh)
+    print_info "Enabling allow_duplicate_ip for Docker/Tailscale compatibility"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    else
+        sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    fi
+    
     # Verify gRPC is enabled
     print_info "Verifying gRPC configuration:"
     grep -A2 "\[grpc\]" "$APP_TOML" | grep "enable"

--- a/peer_node.sh
+++ b/peer_node.sh
@@ -131,6 +131,14 @@ if [[ $1 == "init" ]]; then
     else
         sed -i 's/prometheus = false/prometheus = true/' "$CONFIG"
     fi
+    
+    # Allow duplicate IPs (for Docker NAT / Tailscale mesh)
+    print_info "Enabling allow_duplicate_ip for Docker/Tailscale compatibility"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    else
+        sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    fi
 
     # Configure block time (1 block every 8 seconds)
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/multi_seed_node_prod.sh
+++ b/scripts/multi_seed_node_prod.sh
@@ -339,6 +339,14 @@ initialize_multi_seed() {
         sed -i '/^\[grpc\]/,/^\[/ s|^enable = false|enable = true|' "$APP_TOML"
     fi
     
+    # Allow duplicate IPs (for Docker NAT / Tailscale mesh)
+    print_info "Enabling allow_duplicate_ip for Docker/Tailscale compatibility"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    else
+        sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    fi
+    
     # Configure RPC access (bind to all interfaces for Docker)
     print_info "Enabling RPC services"
     if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -376,7 +384,7 @@ start_node() {
             --metrics "$TRACE" \
             --log_level $LOGLEVEL \
             --minimum-gas-prices=0.0001nxq \
-            --json-rpc.api eth,txpool,personal,net,debug,web3 \
+            --json-rpc.api eth,txpool,net,debug,web3 \
             --home "$HOMEDIR" \
             --chain-id "$CHAINID"
     else
@@ -385,7 +393,7 @@ start_node() {
             --metrics "$TRACE" \
             --log_level $LOGLEVEL \
             --minimum-gas-prices=0.0001nxq \
-            --json-rpc.api eth,txpool,personal,net,debug,web3 \
+            --json-rpc.api eth,txpool,net,debug,web3 \
             --home "$HOMEDIR" \
             --chain-id "$CHAINID"
     fi

--- a/scripts/peer_node_prod.sh
+++ b/scripts/peer_node_prod.sh
@@ -280,6 +280,14 @@ initialize_peer() {
         sed -i 's/enabled = false/enabled = true/' "$APP_TOML"
     fi
     
+    # Allow duplicate IPs (for Docker NAT / Tailscale mesh)
+    print_info "Enabling allow_duplicate_ip for Docker/Tailscale compatibility"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    else
+        sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    fi
+    
     # Enable gRPC
     if [[ "$OSTYPE" == "darwin"* ]]; then
         sed -i '' '/^\[grpc\]/,/^\[/ s|^enable = false|enable = true|' "$APP_TOML"

--- a/scripts/seed_node_prod.sh
+++ b/scripts/seed_node_prod.sh
@@ -286,6 +286,14 @@ initialize_blockchain() {
         sed -i '/^\[grpc\]/,/^\[/ s|^enable = false|enable = true|' "$APP_TOML"
     fi
     
+    # Allow duplicate IPs (for Docker NAT / Tailscale mesh)
+    print_info "Enabling allow_duplicate_ip for Docker/Tailscale compatibility"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    else
+        sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    fi
+    
     # Change proposal periods
     print_info "Setting up proposal periods (5 minutes for voting)"
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/seed_node.sh
+++ b/seed_node.sh
@@ -297,6 +297,14 @@ initialize_blockchain() {
         sed -i 's/enabled = false/enabled = true/' "$APP_TOML"
     fi
     
+    # Allow duplicate IPs (for Docker NAT / Tailscale mesh)
+    print_info "Enabling allow_duplicate_ip for Docker/Tailscale compatibility"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    else
+        sed -i 's/allow_duplicate_ip = false/allow_duplicate_ip = true/' "$CONFIG"
+    fi
+    
     # Change proposal periods
     print_info "Setting up proposal periods (5 minutes for voting)"
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/test_personal_api.sh
+++ b/test_personal_api.sh
@@ -9,10 +9,10 @@ echo "=========================================="
 echo ""
 
 # JSON-RPC endpoint
-RPC_URL="http://localhost:8545"
+RPC_URL="http://100.108.8.123:8545"
 
 # Test account (you'll need to use a real account from your keyring)
-TEST_ADDRESS="0x1234567890123456789012345678901234567890"
+TEST_ADDRESS="0xD6aAB23888550C0d7177eB23f5811065855BAAe7"
 TEST_TO="0x0987654321098765432109876543210987654321"
 
 echo "1. Testing eth_sendTransaction (should fail - requires personal API)"

--- a/tests/e2e/init-node.sh
+++ b/tests/e2e/init-node.sh
@@ -163,5 +163,5 @@ evmosd validate-genesis
 evmosd start "$TRACE" \
   --log_level $LOGLEVEL \
   --minimum-gas-prices=0.0001aevmos \
-  --json-rpc.api eth,txpool,personal,net,debug,web3 \
+  --json-rpc.api eth,txpool,net,debug,web3 \
   --chain-id "$CHAINID"


### PR DESCRIPTION
…le scripts

- Added functionality to allow duplicate IPs in multi_seed_node.sh, peer_node.sh, seed_node.sh, and their production counterparts.
- Updated configuration files to set `allow_duplicate_ip` to true, enhancing compatibility with Docker NAT and Tailscale mesh networks.
- Adjusted JSON-RPC API parameters in relevant scripts to maintain consistency.